### PR TITLE
add support for "parameter properties"

### DIFF
--- a/ts/main.ts
+++ b/ts/main.ts
@@ -449,6 +449,10 @@ class Program {
                         break;
                     case SK.Constructor:
                         addFunc(<ts.ConstructorDeclaration>node, SEK.constructorImplementationElement);
+                        (<ts.ConstructorDeclaration>node).parameters.forEach(function(p) {
+                            if (p.flags & ts.NodeFlags.AccessibilityModifier)
+                                add(p, SEK.memberVariableElement, p.symbol);
+                        });
                         break;
                     case SK.GetAccessor:
                         addFunc(<ts.AccessorDeclaration>node, SEK.memberGetAccessorElement, node.symbol);


### PR DESCRIPTION
Show (in the Navigator) class members that are declared via [parameter properties](https://www.typescriptlang.org/docs/handbook/classes.html#parameter-properties) of the constructor.