### PR TITLE
avoid add \n when ENTER pressed inside template strings

### DIFF
--- a/src/netbeanstypescript/JsTypedTextInterceptor.java
+++ b/src/netbeanstypescript/JsTypedTextInterceptor.java
@@ -72,7 +72,7 @@ public class JsTypedTextInterceptor implements TypedTextInterceptor {
     private static final TokenId[] REGEXP_TOKENS = { JsTokenId.REGEXP, JsTokenId.REGEXP_END };
 
     /** Tokens which indicate that we're within a literal string */
-    private final static TokenId[] STRING_TOKENS = { JsTokenId.STRING, JsTokenId.STRING_END };
+    private final static TokenId[] STRING_TOKENS = { JsTokenId.STRING, JsTokenId.STRING_TEMPLATE, JsTokenId.STRING_END };
 
     private final Language<JsTokenId> language;
 

--- a/src/netbeanstypescript/api/lexer/JsTokenId.java
+++ b/src/netbeanstypescript/api/lexer/JsTokenId.java
@@ -87,6 +87,7 @@ public enum JsTokenId implements TokenId {
 
     STRING_BEGIN(null, "string"), // NOI18N
     STRING(null, "string"), // NOI18N
+    STRING_TEMPLATE(null, "string"), // NOI18N
     STRING_END(null, "string"), // NOI18N
 
     REGEXP_BEGIN(null, "mod-regexp"), // NOI18N

--- a/src/netbeanstypescript/api/lexer/TSLexer.java
+++ b/src/netbeanstypescript/api/lexer/TSLexer.java
@@ -148,7 +148,7 @@ public class TSLexer implements Lexer<JsTokenId> {
             } else {
                 if (ch == quote) {
                     lastTokType = TERM;
-                    return factory.createToken(JsTokenId.STRING);
+                    return factory.createToken(quote == '`' ? JsTokenId.STRING_TEMPLATE : JsTokenId.STRING);
                 }
                 if (quote == '`') {
                     if (ch == '$') {


### PR DESCRIPTION
Multiline strings which are coded as [template strings](https://www.typescriptlang.org/docs/handbook/basic-types.html) don`t require \n symbol.

It would be better to synchronize plugin source with fresh [javascript2.lexer](http://hg.netbeans.org/web-main/file/tip/javascript2.lexer/src/org/netbeans/modules/javascript2/lexer/api) and [javascript2.editor](http://hg.netbeans.org/web-main/file/tip/javascript2.editor/src/org/netbeans/modules/javascript2/editor), but it seems to be a too complex work.